### PR TITLE
ORKFormItemCell Input Accessory View

### DIFF
--- a/ResearchKit/Artwork.xcassets/Active/handtapping01.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/handtapping01.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "handtapping01@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "handtapping01@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "handtapping01@3x.png"
+      "filename" : "handtapping01@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "handtapping01@2x~ipad.png"
+      "filename" : "handtapping01@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/handtapping02.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/handtapping02.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "handtapping02@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "handtapping02@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "handtapping02@3x.png"
+      "filename" : "handtapping02@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "handtapping02@2x~ipad.png"
+      "filename" : "handtapping02@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/heart-fitness.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/heart-fitness.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "heart-fitness@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "heart-fitness@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "heart-fitness@3x.png"
+      "filename" : "heart-fitness@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "heart-fitness@2x~ipad.png"
+      "filename" : "heart-fitness@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/heartbeat.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/heartbeat.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "heartbeat@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "heartbeat@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "heartbeat@3x.png"
+      "filename" : "heartbeat@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "heartbeat@2x~ipad.png"
+      "filename" : "heartbeat@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/holepegtest1.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/holepegtest1.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "holepegtest1@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "holepegtest1@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "holepegtest1@3x.png"
+      "filename" : "holepegtest1@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "holepegtest1@2x~ipad.png"
+      "filename" : "holepegtest1@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/holepegtest2.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/holepegtest2.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "holepegtest2@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "holepegtest2@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "holepegtest2@3x.png"
+      "filename" : "holepegtest2@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "holepegtest2@2x~ipad.png"
+      "filename" : "holepegtest2@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/holepegtest3.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/holepegtest3.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "holepegtest3@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "holepegtest3@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "holepegtest3@3x.png"
+      "filename" : "holepegtest3@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "holepegtest3@2x~ipad.png"
+      "filename" : "holepegtest3@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/holepegtest4.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/holepegtest4.imageset/Contents.json
@@ -6,6 +6,11 @@
     },
     {
       "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
       "filename" : "holepegtest4@2x.png",
       "scale" : "2x"
     },
@@ -17,6 +22,11 @@
     {
       "idiom" : "iphone",
       "filename" : "holepegtest4@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
       "scale" : "3x"
     },
     {

--- a/ResearchKit/Artwork.xcassets/Active/holepegtest5.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/holepegtest5.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "holepegtest5@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "holepegtest5@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "holepegtest5@3x.png"
+      "filename" : "holepegtest5@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "holepegtest5@2x~ipad.png"
+      "filename" : "holepegtest5@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/holepegtest6.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/holepegtest6.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "holepegtest6@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "holepegtest6@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "holepegtest6@3x.png"
+      "filename" : "holepegtest6@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "holepegtest6@2x~ipad.png"
+      "filename" : "holepegtest6@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/memory-second-screen.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/memory-second-screen.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "memory-second-screen@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "memory-second-screen@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "memory-second-screen@3x.png"
+      "filename" : "memory-second-screen@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "memory-second-screen@2x~ipad.png"
+      "filename" : "memory-second-screen@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phone-memory.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phone-memory.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phone-memory@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phone-memory@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phone-memory@3x.png"
+      "filename" : "phone-memory@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phone-memory@2x~ipad.png"
+      "filename" : "phone-memory@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phonefrequencywaves.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phonefrequencywaves.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phonefrequencywaves@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phonefrequencywaves@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phonefrequencywaves@3x.png"
+      "filename" : "phonefrequencywaves@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phonefrequencywaves@2x~ipad.png"
+      "filename" : "phonefrequencywaves@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phoneholepeg.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phoneholepeg.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phoneholepeg@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phoneholepeg@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phoneholepeg@3x.png"
+      "filename" : "phoneholepeg@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phoneholepeg@2x~ipad.png"
+      "filename" : "phoneholepeg@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phonepsat.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phonepsat.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phonepsat@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phonepsat@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phonepsat@3x.png"
+      "filename" : "phonepsat@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phonepsat@2x~ipad.png"
+      "filename" : "phonepsat@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phoneshake.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phoneshake.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phoneshake@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phoneshake@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phoneshake@3x.png"
+      "filename" : "phoneshake@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phoneshake@2x~ipad.png"
+      "filename" : "phoneshake@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phoneshakecircle.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phoneshakecircle.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phoneshakecircle@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phoneshakecircle@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phoneshakecircle@3x.png"
+      "filename" : "phoneshakecircle@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phoneshakecircle@2x~ipad.png"
+      "filename" : "phoneshakecircle@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phonesoundwaves.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phonesoundwaves.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phonesoundwaves@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phonesoundwaves@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phonesoundwaves@3x.png"
+      "filename" : "phonesoundwaves@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phonesoundwaves@2x~ipad.png"
+      "filename" : "phonesoundwaves@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phonetapping.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phonetapping.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phonetapping@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phonetapping@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phonetapping@3x.png"
+      "filename" : "phonetapping@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phonetapping@2x~ipad.png"
+      "filename" : "phonetapping@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phonetapping_notap.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phonetapping_notap.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phonetapping_notap@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phonetapping_notap@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phonetapping_notap@3x.png"
+      "filename" : "phonetapping_notap@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phonetapping_notap@2x~ipad.png"
+      "filename" : "phonetapping_notap@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phonewaves.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phonewaves.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phonewaves@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phonewaves@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phonewaves@3x.png"
+      "filename" : "phonewaves@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phonewaves@2x~ipad.png"
+      "filename" : "phonewaves@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/phonewaves_inverted.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/phonewaves_inverted.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "phonewaves_inverted@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "phonewaves_inverted@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "phonewaves_inverted@3x.png"
+      "filename" : "phonewaves_inverted@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "phonewaves_inverted@2x~ipad.png"
+      "filename" : "phonewaves_inverted@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/pocket.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/pocket.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "pocket@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "pocket@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "pocket@3x.png"
+      "filename" : "pocket@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "pocket@2x~ipad.png"
+      "filename" : "pocket@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/sittingman.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/sittingman.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "sittingman@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "sittingman@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "sittingman@3x.png"
+      "filename" : "sittingman@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "sittingman@2x~ipad.png"
+      "filename" : "sittingman@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/timed-walkingman-outbound.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/timed-walkingman-outbound.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "timed-walkingman-outbound@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "timed-walkingman-outbound@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "timed-walkingman-outbound@3x.png"
+      "filename" : "timed-walkingman-outbound@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "timed-walkingman-outbound@2x~ipad.png"
+      "filename" : "timed-walkingman-outbound@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/timed-walkingman-return.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/timed-walkingman-return.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "timed-walkingman-return@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "timed-walkingman-return@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "timed-walkingman-return@3x.png"
+      "filename" : "timed-walkingman-return@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "timed-walkingman-return@2x~ipad.png"
+      "filename" : "timed-walkingman-return@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/timer.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/timer.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "timer@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "timer@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "timer@3x.png"
+      "filename" : "timer@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "timer@2x~ipad.png"
+      "filename" : "timer@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/walkingman.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/walkingman.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "walkingman@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "walkingman@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "walkingman@3x.png"
+      "filename" : "walkingman@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "walkingman@2x~ipad.png"
+      "filename" : "walkingman@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Active/walkingman_monitor.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Active/walkingman_monitor.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "walkingman_monitor@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "walkingman_monitor@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "walkingman_monitor@3x.png"
+      "filename" : "walkingman_monitor@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "walkingman_monitor@2x~ipad.png"
+      "filename" : "walkingman_monitor@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Consent/consent_01.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Consent/consent_01.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "consent_01@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "consent_01@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "consent_01@3x.png"
+      "filename" : "consent_01@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "consent_01@2x~ipad.png"
+      "filename" : "consent_01@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Consent/consent_02.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Consent/consent_02.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "consent_02@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "consent_02@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "consent_02@3x.png"
+      "filename" : "consent_02@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "consent_02@2x~ipad.png"
+      "filename" : "consent_02@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Consent/consent_03.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Consent/consent_03.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "consent_03@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "consent_03@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "consent_03@3x.png"
+      "filename" : "consent_03@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "consent_03@2x~ipad.png"
+      "filename" : "consent_03@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Consent/consent_04.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Consent/consent_04.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "consent_04@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "consent_04@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "consent_04@3x.png"
+      "filename" : "consent_04@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "consent_04@2x~ipad.png"
+      "filename" : "consent_04@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Consent/consent_05.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Consent/consent_05.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "consent_05@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "consent_05@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "consent_05@3x.png"
+      "filename" : "consent_05@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "consent_05@2x~ipad.png"
+      "filename" : "consent_05@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Consent/consent_06.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Consent/consent_06.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "consent_06@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "consent_06@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "consent_06@3x.png"
+      "filename" : "consent_06@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "consent_06@2x~ipad.png"
+      "filename" : "consent_06@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Artwork.xcassets/Consent/consent_07.imageset/Contents.json
+++ b/ResearchKit/Artwork.xcassets/Consent/consent_07.imageset/Contents.json
@@ -6,8 +6,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "2x",
-      "filename" : "consent_07@2x.png"
+      "subtype" : "retina4",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "iphone",
+      "filename" : "consent_07@2x.png",
+      "scale" : "2x"
     },
     {
       "idiom" : "iphone",
@@ -16,8 +21,13 @@
     },
     {
       "idiom" : "iphone",
-      "scale" : "3x",
-      "filename" : "consent_07@3x.png"
+      "filename" : "consent_07@3x.png",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "subtype" : "retina4",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",
@@ -25,8 +35,8 @@
     },
     {
       "idiom" : "ipad",
-      "scale" : "2x",
-      "filename" : "consent_07@2x~ipad.png"
+      "filename" : "consent_07@2x~ipad.png",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -270,16 +270,14 @@ static const CGFloat HorizontalMargin = 15.0;
     NSIndexPath *current = [self.parentTableView indexPathForCell:self];
 
 
-    UIBarButtonItem *next = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"arrowRight" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil]
-                                                             style:UIBarButtonItemStylePlain
-                                                            target:self
-                                                            action:@selector(nextResponder:)];
+    UIBarButtonItem *next = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:102 // undocumented ">" character
+                                                                          target:self
+                                                                          action:@selector(nextResponder:)];
     next.width = 24;
 
-    UIBarButtonItem *prev = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"arrowLeft" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil]
-                                                             style:UIBarButtonItemStylePlain
-                                                            target:self
-                                                            action:@selector(prevResponder:)];
+    UIBarButtonItem *prev = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:101 // undocumented "<" character
+                                                                          target:self
+                                                                          action:@selector(prevResponder:)];
     prev.width = 24;
 
     [toolbar setItems:@[fixed, prev, next, flex, done]];


### PR DESCRIPTION
All Text Entries now have `< > done` as their 3 buttons on the input view.
This is for pickers as well as number/text entry.

Please Ignore the Updates to `Contents.json` files... Xcode Did this.

The [`ORKFormItemCell.m`](https://github.com/digitalinfuzion-corporate/ResearchKit/compare/master...digitalinfuzion-corporate:form-input-accessory-view?expand=1#diff-816e1051181239e6267dc1b0336367bd) is where all the changes actually are.