### PR TITLE
MultipleValuePicker Column Width

### DIFF
--- a/ResearchKit/Common/ORKMultipleValuePicker.m
+++ b/ResearchKit/Common/ORKMultipleValuePicker.m
@@ -242,13 +242,34 @@
     }
 }
 
-- (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component {
-    NSUInteger idx = [self convertFromPickerViewComponent:component];
-    if (idx == NSNotFound) {
-        return _separator;
+/**
+ @discussion replaced the method which returns a string with a method that returns a UILabel, sized to fit correctly
+ */
+- (UIView *)pickerView:(UIPickerView *)pickerView viewForRow:(NSInteger)row forComponent:(NSInteger)component reusingView:(UIView *)view {
+
+    // Re-Use View
+    UILabel *label;
+    if (view && [view isKindOfClass:[UILabel class]]) {
+        label = (UILabel *)view;
     } else {
-        return [[self.helpers[idx] textChoiceAtIndex:row] text] ?: @"";
+        label = [UILabel new];
     }
+
+    // Get Same Text as previous method
+    NSUInteger idx = [self convertFromPickerViewComponent:component];
+    NSString *text;
+    if (idx == NSNotFound) {
+        text = _separator;
+    } else {
+        text = [[self.helpers[idx] textChoiceAtIndex:row] text] ?: @"";
+    }
+
+    // Get the label to size itself correctly
+    label.text = text;
+    [label sizeToFit];
+
+    return label;
+
 }
 
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component {

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -75,6 +75,7 @@ enum TaskListRow: Int, CustomStringConvertible {
     case timeIntervalQuestion
     case timeOfDayQuestion
     case valuePickerChoiceQuestion
+    case multipleValuePickerChoiceQuestion
     case validatedTextQuestion
     case imageCapture
     case videoCapture
@@ -139,6 +140,7 @@ enum TaskListRow: Int, CustomStringConvertible {
                     .timeIntervalQuestion,
                     .timeOfDayQuestion,
                     .valuePickerChoiceQuestion,
+                    .multipleValuePickerChoiceQuestion,
                     .validatedTextQuestion,
                     .imageCapture,
                     .videoCapture,
@@ -230,7 +232,10 @@ enum TaskListRow: Int, CustomStringConvertible {
             
         case .valuePickerChoiceQuestion:
             return NSLocalizedString("Value Picker Choice Question", comment: "")
-            
+
+        case .multipleValuePickerChoiceQuestion:
+            return NSLocalizedString("Multiple Value Picker Choice Question", comment: "")
+
         case .validatedTextQuestion:
             return NSLocalizedString("Validated Text Question", comment: "")
             
@@ -404,6 +409,10 @@ enum TaskListRow: Int, CustomStringConvertible {
         // Task with a value picker.
         case valuePickerChoiceQuestionTask
         case valuePickerChoiceQuestionStep
+
+        // Task with a multiple value picker.
+        case multipleValuePickerChoiceQuestionTask
+        case multipleValuePickerChoiceQuestionStep
         
         // Task with an example of validated text entry.
         case validatedTextQuestionTask
@@ -533,7 +542,10 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         case .valuePickerChoiceQuestion:
                 return valuePickerChoiceQuestionTask
-            
+
+        case .multipleValuePickerChoiceQuestion:
+            return multipleValuePickerChoiceQuestionTask
+
         case .validatedTextQuestion:
             return validatedTextQuestionTask
             
@@ -984,6 +996,36 @@ enum TaskListRow: Int, CustomStringConvertible {
         questionStep.text = exampleDetailText
         
         return ORKOrderedTask(identifier: String(describing:Identifier.valuePickerChoiceQuestionTask), steps: [questionStep])
+    }
+
+    /**
+     This task demonstrates a survey question using a value picker wheel.
+     Compare with the `textChoiceQuestionTask` and `imageChoiceQuestionTask`
+     which can serve a similar purpose.
+     */
+    private var multipleValuePickerChoiceQuestionTask: ORKTask {
+
+        let month = ["Unknown", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Sep", "Oct", "Nov", "Dec"]
+        let monthChoices = month.flatMap { ORKTextChoice(text: $0, value: $0 as NSString) }
+        let monthAnswer = ORKAnswerFormat.valuePickerAnswerFormat(with: monthChoices)
+
+        let days = ["Unknown"] + ((1...31).flatMap { String($0) })
+        let dayChoices = days.flatMap { ORKTextChoice(text: $0, value: $0 as NSString) }
+        let dayAnswer = ORKAnswerFormat.valuePickerAnswerFormat(with: dayChoices)
+
+        let years = 1900...2017
+        let yearChoices = years.flatMap { ORKTextChoice(text: String($0), value: $0 as NSNumber) }
+        let yearAnswer = ORKAnswerFormat.valuePickerAnswerFormat(with: yearChoices)
+
+
+        let answerFormat = ORKAnswerFormat.multipleValuePickerAnswerFormat(withValuePickers: [monthAnswer, dayAnswer, yearAnswer]);
+
+        let questionStep = ORKQuestionStep(identifier: String(describing:Identifier.multipleValuePickerChoiceQuestionStep), title: exampleQuestionText,
+                                           answer: answerFormat)
+
+        questionStep.text = exampleDetailText
+
+        return ORKOrderedTask(identifier: String(describing:Identifier.multipleValuePickerChoiceQuestionTask), steps: [questionStep])
     }
 
     /**


### PR DESCRIPTION
Uses a `UILabel` instead of the `NSString` so the value picker is given the appropriate text width.

Added an Option to view a MultipleValuePicker in the `ORKCatalog` project (for testing purposes)