### PR TITLE
Visual Consent Continue Button Title

### DIFF
--- a/ResearchKit/Consent/ORKConsentSection.h
+++ b/ResearchKit/Consent/ORKConsentSection.h
@@ -179,6 +179,12 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, nullable) NSString *formalTitle;
 
 /**
+ The continue button title, to be shown on the continue button.
+ This overrides anything set in the VisualConsentStepViewController if non-nil
+ */
+@property (nonatomic, copy, nullable) NSString *continueButtonTitle;
+
+/**
  A short summary of the content in a localized string.
  
  The summary is displayed as description text in the animated consent sequence.

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.m
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.m
@@ -640,15 +640,24 @@
     } else if (index >= [self pageCount]) {
         consentViewController = nil;
     } else {
-        ORKConsentSceneViewController *sceneViewController = [[ORKConsentSceneViewController alloc] initWithSection:[self visualSections][index]];
+        ORKConsentSection *section = [self visualSections][index];
+        ORKConsentSceneViewController *sceneViewController = [[ORKConsentSceneViewController alloc] initWithSection:section];
         consentViewController = sceneViewController;
-        
+
+
         if (index == [self pageCount]-1) {
+            if (section.continueButtonTitle != nil) {
+                self.continueButtonTitle = section.continueButtonTitle;
+            }
             sceneViewController.continueButtonItem = self.continueButtonItem;
+            
         } else {
             NSString *buttonTitle = ORKLocalizedString(@"BUTTON_NEXT", nil);
             if (sceneViewController.section.type == ORKConsentSectionTypeOverview) {
                 buttonTitle = ORKLocalizedString(@"BUTTON_GET_STARTED", nil);
+            }
+            if (section.continueButtonTitle != nil) {
+                buttonTitle = section.continueButtonTitle;
             }
             
             sceneViewController.continueButtonItem = [[UIBarButtonItem alloc] initWithTitle:buttonTitle style:UIBarButtonItemStylePlain target:self action:@selector(next)];


### PR DESCRIPTION
Adds the continueButtonTitle property to the VisualConsent Section

Requires this pull request on the main branch: https://github.com/digitalinfuzion-corporate/ios-nof1-research-kit-core-app/pull/388