### PR TITLE
Consent Review Step Changes

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewController.h
+++ b/ResearchKit/Consent/ORKConsentReviewController.h
@@ -40,19 +40,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)consentReviewControllerDidAcknowledge:(ORKConsentReviewController *)consentReviewController;
 - (void)consentReviewControllerDidCancel:(ORKConsentReviewController *)consentReviewController;
+- (void)consentReviewControllerDidContinue:(ORKConsentReviewController *)consentReviewController;
 
 @end
 
 
 @interface ORKConsentReviewController : UIViewController
 
-- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate;
+- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom;
 
 @property (nonatomic, strong, nullable) UIWebView *webView;
 
 @property (nonatomic, weak, nullable) id<ORKConsentReviewControllerDelegate> delegate;
 
 @property (nonatomic, strong, nullable) NSString *localizedReasonForConsent;
+
+@property (nonatomic) BOOL requiresAgreement;
 
 @end
 

--- a/ResearchKit/Consent/ORKConsentReviewStep.h
+++ b/ResearchKit/Consent/ORKConsentReviewStep.h
@@ -97,11 +97,30 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, strong, readonly, nullable) ORKConsentSignature *signature;
 
 /**
+ When set to YES, the consent document must be scrolled to the bottom to enable the `Agree` button.
+ */
+@property (nonatomic) BOOL requiresScrollToBottom;
+
+/**
  A user-visible description of the reason for agreeing to consent in a localized string.
  
  The reason for consent is presented in the confirmation dialog that users see when giving their consent.
   */
 @property (nonatomic, copy, nullable) NSString *reasonForConsent;
+
+
+/**
+ a value indicating whether or not this requires agreement, since this step doesn't store an ORKResult it must be asked
+ in a subsequent question in order to get and store the value for ODM
+ */
+@property (nonatomic) BOOL requiresAgreement;
+
+
+/**
+ A user-visible description of the instructions. Should say tap 'next' or 'agree' depending on how you've configured `requiresAgreement`.
+
+ */
+@property (nonatomic, copy, nullable) NSString *instructions;
 
 @end
 

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -227,12 +227,18 @@ static NSString *const _FamilyNameIdentifier = @"family";
             signature.familyName = _signatureLast;
         }
     }
+
+    NSString *detail = [[self consentReviewStep] instructions];
+    if (detail == nil) {
+        detail = ORKLocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil);
+    }
     
     NSString *html = [document mobileHTMLWithTitle:ORKLocalizedString(@"CONSENT_REVIEW_TITLE", nil)
-                                             detail:ORKLocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
+                                             detail:detail];
 
-    ORKConsentReviewController *reviewViewController = [[ORKConsentReviewController alloc] initWithHTML:html delegate:self];
+    ORKConsentReviewController *reviewViewController = [[ORKConsentReviewController alloc] initWithHTML:html delegate:self requiresScrollToBottom: [[self consentReviewStep] requiresScrollToBottom]];
     reviewViewController.localizedReasonForConsent = [[self consentReviewStep] reasonForConsent];
+    reviewViewController.requiresAgreement = [[self consentReviewStep] requiresAgreement];
     return reviewViewController;
 }
 
@@ -456,6 +462,16 @@ static NSString *const _SignatureStepIdentifier = @"signatureStep";
     _documentReviewed = NO;
     [self notifyDelegateOnResultChange];
     
+    [self goForward];
+}
+
+- (void)consentReviewControllerDidContinue:(ORKConsentReviewController *)consentReviewController {
+    _documentReviewed = YES;
+    _signatureFirst = nil;
+    _signatureLast = nil;
+    _signatureImage = nil;
+    [self notifyDelegateOnResultChange];
+
     [self goForward];
 }
 


### PR DESCRIPTION
Adds the following properties to the Consent Review Step:

    "step": "consentReview",
    "requiresAgreement": false,
    "requiresScrollToBottom": false,
    "instructions": "Review the form below, and tap Next if you're ready to continute.",

`requiresAgreement` changes the bottom toolbar from [Disagree Agree] to [     Next] - default `true`
`requiresScrollToBottom` enables the `next` or `agree` buttons by default - default `true`
`instructions` replaces the instruction next so you can change the language from "tap Agree" to "tap Next" - default `nil` (uses the built-in ResearchKit instruction Text)

requires the N of 1 mobile app pull request: https://github.com/digitalinfuzion-corporate/ios-nof1-research-kit-core-app/pull/389